### PR TITLE
Feature update readme license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,17 @@
+This work was created by participants in the DataONE project, and is
+jointly copyrighted by participating institutions in DataONE. For
+more information on DataONE, see our web site at http://dataone.org.
+
+  Copyright 2020 DataONE
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,54 @@
 # SpeedBagIt
 [![Build Status](https://travis-ci.org/NCEAS/eml.svg?branch=master)](https://travis-ci.org/NCEAS/eml)
 
+- **Authors**: Thomas Thelen ([NCEAS](http://www.nceas.ucsb.edu))
+- **License**: [Apache 2](http://opensource.org/licenses/Apache-2.0)
+- [**Submit Bugs and feature requests**](https://github.com/DataONEorg/rdataone/issues)
+
 A fast, minimal BagIt library that serves bags without touching the filesystem. Ever.
+This library was designed for servers serving zip files that conform 
+to the BagIt specification. This is unique to other BagIt libraries in that it doesn't 
+create a temporary zip file of the bag on disk. Instead, it performs checksumming and size calculations 
+on the fly _as the bag is being served_. This avoids unnecessarily copying data files to disk which 
+is a common bottleneck for delivering content.
 
 ### Installing
-To use SpeedBagIt in your project, add the following to your `pom.xml`.
 
+#### Maven
+To use SpeedBagIt in your project, first add the DataONE maven repository to your project's `pom.xml` file.
+```
+<repository>
+    <id>dataone.org</id>
+    <url>http://maven.dataone.org/</url>
+    <releases>
+        <enabled>true</enabled>
+    </releases>
+    <snapshots>
+        <enabled>true</enabled>
+    </snapshots>
+</repository>
+```
+Then, add the SpeedBagIt dependency to the `pom.xml` file.
 ```
 <dependency>
     <groupId>org.dataone</groupId>
-    <artifactId>SpeedBagIt</artifactId>
+    <artifactId>speedbagit</artifactId>
     <version>1.0</version>
 </dependency>
 ```
 
-### Usage
+#### Compiling & Including the Jar
+SpeedBagIt can also be installed by cloning this repository and including the 
+resulting jar file in your project.
+
+```
+git clone https://github.com/DataONEorg/speed-bagit.git
+cd speed-bagit
+mvn install
+```
+
+### Quick Start
+
 
 #### Customizing bagit.txt
 
@@ -38,3 +72,36 @@ try {
 ```
 
 ### Contributing
+
+The takeaway for contributing is that feature branches are created off of the `develop` branch and pull requests should be made 
+into the `develop` branch rather than `master`. 
+
+For example, the workflow to create a pull request for a feature that adds support for fetch.txt follows
+
+- Create an issue describing your planned changes, or add a comment to an existing relevant issue
+- Checkout the `develop` branch, followed by `git checkout -b feature_support_fetch_file`
+- Commit your changes to the `feature_support_fetch_file` branch
+- Create a pull request from `feature_support_fetch_file` into `develop` and outline the code changes and how to test it
+- Once the code is reviewed, our team will merge in your changes and you're done!
+
+#### Code Style
+This project conforms to the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html) and new 
+contributions should follow suite.
+
+#### Unit Tests
+Unit tests should be created for all new classes and if possible, public methods. When writing unit tests, keep in mind that 
+the points are 
+ - After your contribution is merged, no one accidentally breaks it in the future
+ - Early validation of potential bugs in your code
+ - Examples for future developers and users to see how the classes and methods can be used
+
+## Acknowledgments
+Work on this package was supported by:
+
+- NSF DIBBS grant [#1541450](https://www.nsf.gov/awardsearch/showAward?AWD_ID=1541450) to B. Ludaescher, V. Stodden, N. Gaffney, M. Turk, and K. Chard
+
+Additional support was provided for working group collaboration by the National Center for Ecological Analysis and Synthesis, a Center funded by the University of California, Santa Barbara, and the State of California.
+
+[![nceas_footer](https://live-ncea-ucsb-edu-v01.pantheonsite.io/sites/default/files/2020-03/NCEAS-full%20logo-4C.png)](http://www.nceas.ucsb.edu)
+
+[![dataone_footer](https://www.dataone.org/sites/all/images/DataONE_LOGO.jpg)](http://dataone.org)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # SpeedBagIt
-[![Build Status](https://travis-ci.org/NCEAS/eml.svg?branch=master)](https://travis-ci.org/NCEAS/eml)
+[![Build Status](https://travis-ci.com/DataONEorg/speed-bagit.svg?branch=main)](https://travis-ci.com/DataONEorg/speed-bagit)
 
 - **Authors**: Thomas Thelen ([NCEAS](http://www.nceas.ucsb.edu))
 - **License**: [Apache 2](http://opensource.org/licenses/Apache-2.0)
-- [**Submit Bugs and feature requests**](https://github.com/DataONEorg/rdataone/issues)
+- [**Submit Bugs and feature requests**](https://github.com/DataONEorg/speed-bagit/issues)
 
 A fast, minimal BagIt library that serves bags without touching the filesystem. Ever.
 This library was designed for servers serving zip files that conform 
-to the BagIt specification. This is unique to other BagIt libraries in that it doesn't 
+to the BagIt specification. This differs from other BagIt libraries in that it doesn't 
 create a temporary zip file of the bag on disk. Instead, it performs checksumming and size calculations 
 on the fly _as the bag is being served_. This avoids unnecessarily copying data files to disk which 
 is a common bottleneck for delivering content.
@@ -102,6 +102,6 @@ Work on this package was supported by:
 
 Additional support was provided for working group collaboration by the National Center for Ecological Analysis and Synthesis, a Center funded by the University of California, Santa Barbara, and the State of California.
 
-[![nceas_footer](https://live-ncea-ucsb-edu-v01.pantheonsite.io/sites/default/files/2020-03/NCEAS-full%20logo-4C.png)](http://www.nceas.ucsb.edu)
+[![nceas_footer](https://www.nceas.ucsb.edu/sites/default/files/2020-03/NCEAS-full%20logo-4C.png)](http://www.nceas.ucsb.edu)
 
 [![dataone_footer](https://www.dataone.org/sites/all/images/DataONE_LOGO.jpg)](http://dataone.org)


### PR DESCRIPTION
### Changes

#### LICENSE file
Fixes issue #5 
I added a LICENSE file, which I took from the bookkeeper repository. The only difference is that I named the file LICENSE rather than License.txt based on [this](https://www.apache.org/licenses/LICENSE-2.0#:~:text=You%20should%20include%20a%20copy,also%20including%20a%20NOTICE%20file.) blurb.

#### Updated Readme.txt
Fixes issue #3 
I took pieces from the rdataone library's readme (see the header, footer, and renaming the Usage section) and included them here. I also used the bookkeeper repository as a template for the installing instructions (pom.xml & building). The last bit is about the contributing guidelines, which was mostly adapted from the MetacatUI project.

I didn't include any further instructions for using the package; as time goes on and things become more stable these will be added.

### Testing
1. Checkout this branch
2. Open the Readme in an editor that supports markdown
3. Confirm that the layout & content looks okay