### PR TITLE
Fix streamed checksum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ Thumbs.db
 venv
 node_modules
 .sass-cache
+/target/

--- a/pom.xml
+++ b/pom.xml
@@ -20,10 +20,16 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.11</version>
-      <scope>test</scope>
+      <groupId>org.junit</groupId>
+      <artifactId>junit-bom</artifactId>
+      <version>5.7.0</version>
+      <type>pom</type>
+      <scope>import</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.5.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,11 @@
       <artifactId>commons-lang3</artifactId>
       <version>3.11</version>
     </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.15</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/dataone/speedbagit/SpeedStream.java
+++ b/src/main/java/org/dataone/speedbagit/SpeedStream.java
@@ -4,15 +4,23 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.security.MessageDigest;
 
+
+import org.apache.commons.codec.binary.Hex;
 /**
  * A stream that computes the checksum and size of an object as it streams.
  *
  */
 public class SpeedStream extends FilterInputStream {
 
-    private MessageDigest cksum;
+    // The object that holds the checksum state & performs checksumming
+    private MessageDigest digest;
+    // The checksum of the object that was streamed
+    private String checksum;
+    // The number of bytes streamed
     private int size;
-
+    // Set to true when the checksum has been set. MessageDigest always has a digest, so it's
+    // impossible to tell whether it's been set or not
+    private boolean checksumSet;
     /**
      * Constructs a new SpeedStream object
      *
@@ -22,8 +30,13 @@ public class SpeedStream extends FilterInputStream {
      */
     public SpeedStream(InputStream in, MessageDigest sum) {
         super(in);
-        this.cksum = sum;
+        this.digest = sum;
+        this.checksum = "";
         this.size = 0;
+
+        // Reset the MessageDigest's state
+        this.digest.reset();
+        this.checksumSet = false;
     }
 
     /**
@@ -35,9 +48,12 @@ public class SpeedStream extends FilterInputStream {
     public int read() throws IOException {
         int b = in.read();
         if (b != -1) {
-            this.cksum.update((byte) b);
+            this.digest.update((byte) b);
+            this.checksumSet = true;
             this.size += 1;
         }
+        byte[] checksum = this.digest.digest();
+        this.checksum = Hex.encodeHexString(checksum);
         return b;
     }
 
@@ -60,10 +76,12 @@ public class SpeedStream extends FilterInputStream {
     public int read(byte[] buf, int off, int len) throws IOException {
         len = in.read(buf, off, len);
         if (len != -1) {
-            this.cksum.update(buf, off, len);
-            // DEVNOTE: This is incorrect; this adds the *maximum* number of bytes read
+            this.digest.update(buf, off, len);
+            this.checksumSet = true;
             this.size += len;
         }
+        byte[] checksum = this.digest.digest();
+        this.checksum = Hex.encodeHexString(checksum);
         return len;
     }
 
@@ -76,10 +94,14 @@ public class SpeedStream extends FilterInputStream {
     }
 
     /**
+     * Returns the checksum of the stream.
+     *
+     * Converts cksum.digest (byte[]) to a String. Since this is a checksum,
+     * it should take up minimal space in memory.
      *
      * @return The checksum of the streamed bytes
      */
-    public byte[] getChecksum() {
-        return this.cksum.digest();
+    public String getChecksum() {
+        return this.checksum;
     }
 }

--- a/src/main/java/org/dataone/speedbagit/SpeedStream.java
+++ b/src/main/java/org/dataone/speedbagit/SpeedStream.java
@@ -14,13 +14,8 @@ public class SpeedStream extends FilterInputStream {
 
     // The object that holds the checksum state & performs checksumming
     private MessageDigest digest;
-    // The checksum of the object that was streamed
-    private String checksum;
     // The number of bytes streamed
     private int size;
-    // Set to true when the checksum has been set. MessageDigest always has a digest, so it's
-    // impossible to tell whether it's been set or not
-    private boolean checksumSet;
     /**
      * Constructs a new SpeedStream object
      *
@@ -31,12 +26,10 @@ public class SpeedStream extends FilterInputStream {
     public SpeedStream(InputStream in, MessageDigest sum) {
         super(in);
         this.digest = sum;
-        this.checksum = "";
         this.size = 0;
 
         // Reset the MessageDigest's state
         this.digest.reset();
-        this.checksumSet = false;
     }
 
     /**
@@ -49,11 +42,8 @@ public class SpeedStream extends FilterInputStream {
         int b = in.read();
         if (b != -1) {
             this.digest.update((byte) b);
-            this.checksumSet = true;
             this.size += 1;
         }
-        byte[] checksum = this.digest.digest();
-        this.checksum = Hex.encodeHexString(checksum);
         return b;
     }
 
@@ -77,11 +67,8 @@ public class SpeedStream extends FilterInputStream {
         len = in.read(buf, off, len);
         if (len != -1) {
             this.digest.update(buf, off, len);
-            this.checksumSet = true;
             this.size += len;
         }
-        byte[] checksum = this.digest.digest();
-        this.checksum = Hex.encodeHexString(checksum);
         return len;
     }
 
@@ -102,6 +89,6 @@ public class SpeedStream extends FilterInputStream {
      * @return The checksum of the streamed bytes
      */
     public String getChecksum() {
-        return this.checksum;
+        return Hex.encodeHexString(this.digest.digest());
     }
 }

--- a/src/test/java/org/dataone/speedbagit/SpeedBagItTest.java
+++ b/src/test/java/org/dataone/speedbagit/SpeedBagItTest.java
@@ -1,5 +1,4 @@
 package org.dataone.speedbagit;
-import org.junit.Test;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
@@ -9,7 +8,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.zip.ZipOutputStream;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Unit test for simple App.

--- a/src/test/java/org/dataone/speedbagit/SpeedFileTest.java
+++ b/src/test/java/org/dataone/speedbagit/SpeedFileTest.java
@@ -1,14 +1,14 @@
 package org.dataone.speedbagit;
 
-import org.junit.Test;
-
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class SpeedFileTest {
 

--- a/src/test/java/org/dataone/speedbagit/SpeedStreamTest.java
+++ b/src/test/java/org/dataone/speedbagit/SpeedStreamTest.java
@@ -27,8 +27,6 @@ public class SpeedStreamTest {
 
         // Make sure that the size always starts at 0
         assertEquals(speedStream.getSize(), 0);
-        // Make sure that the digest doesn't exist
-        assertEquals("", speedStream.getChecksum());
     }
 
     /**
@@ -55,10 +53,6 @@ public class SpeedStreamTest {
         assertEquals(expectedSHA1, speedStream.getChecksum());
         // Check that the SpeedStream size is correct
         assertEquals(testData.length(), speedStream.getSize());
-        // Check that the SpeedStream size matches the size of the result
-        assertEquals(result.toString().length(), testData.length());
-        // Check that all of the data was read
-        assertEquals(testData, result.toString());
     }
 
     /**
@@ -87,7 +81,5 @@ public class SpeedStreamTest {
         assertEquals(testData.length(), speedStream.getSize());
         // Check that the SpeedStream size matches the size of the result
         assertEquals(result.toString().length(), testData.length());
-        // Check that all of the data was read
-        assertEquals(testData, result.toString());
     }
 }

--- a/src/test/java/org/dataone/speedbagit/SpeedStreamTest.java
+++ b/src/test/java/org/dataone/speedbagit/SpeedStreamTest.java
@@ -1,4 +1,93 @@
 package org.dataone.speedbagit;
 
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ByteArrayInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+
 public class SpeedStreamTest {
+
+    /**
+     * Test that the default arguments are correctly set.
+     *
+     */
+    @Test
+    public void testCtor() throws NoSuchAlgorithmException, IOException {
+        String testData = "12345, 345rfdew, 45tgfdr";
+
+        InputStream testDataStream = new ByteArrayInputStream(testData.getBytes());
+        MessageDigest targetDigest = MessageDigest.getInstance("MD5");
+        SpeedStream speedStream = new SpeedStream(testDataStream, targetDigest);
+
+        // Make sure that the size always starts at 0
+        assertEquals(speedStream.getSize(), 0);
+        // Make sure that the digest doesn't exist
+        assertEquals("", speedStream.getChecksum());
+    }
+
+    /**
+     * Tests that the method performing single byte reads is properly working.
+     * The ipnut data should match the data that's read; the checksum and size
+     * should also be correct.
+     */
+    @Test
+    public void testSingleByteRead() throws NoSuchAlgorithmException, IOException {
+        String testData = "12345, 345rfdew, 45tgfdr";
+        String expectedSHA1 = "2fe482afad4e73addf3cb3823ff9b83144763bf2";
+
+        InputStream testDataStream = new ByteArrayInputStream(testData.getBytes());
+        MessageDigest targetDigest = MessageDigest.getInstance("SHA-1");
+        SpeedStream speedStream = new SpeedStream(testDataStream, targetDigest);
+
+        ByteArrayOutputStream result = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int length;
+        while ((length = speedStream.read()) != -1) {
+            result.write(buffer, 0, length);
+        }
+
+        assertEquals(expectedSHA1, speedStream.getChecksum());
+        // Check that the SpeedStream size is correct
+        assertEquals(testData.length(), speedStream.getSize());
+        // Check that the SpeedStream size matches the size of the result
+        assertEquals(result.toString().length(), testData.length());
+        // Check that all of the data was read
+        assertEquals(testData, result.toString());
+    }
+
+    /**
+     * Tests that the method for reading chunks of the stream is properly working. The
+     * size, checksum, and end data should all be correct.
+     *
+     */
+    @Test
+    public void testChecksummingBufferedRead() throws NoSuchAlgorithmException, IOException {
+        String testData = "12345, 345rfdew, 45tgfdr";
+        String expectedSHA1 = "2fe482afad4e73addf3cb3823ff9b83144763bf2";
+
+        InputStream testDataStream = new ByteArrayInputStream(testData.getBytes());
+        MessageDigest targetDigest = MessageDigest.getInstance("SHA-1");
+        SpeedStream speedStream = new SpeedStream(testDataStream, targetDigest);
+
+        ByteArrayOutputStream result = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int length;
+        while ((length = speedStream.read(buffer)) != -1) {
+            result.write(buffer, 0, length);
+        }
+
+        assertEquals(expectedSHA1, speedStream.getChecksum());
+        // Check that the SpeedStream size is correct
+        assertEquals(testData.length(), speedStream.getSize());
+        // Check that the SpeedStream size matches the size of the result
+        assertEquals(result.toString().length(), testData.length());
+        // Check that all of the data was read
+        assertEquals(testData, result.toString());
+    }
 }


### PR DESCRIPTION
This is a pull request that should fix issue #4.

The issue was that every time `digest()` was called, the digest was reset. This was getting called with each `read`; removing it from the method fixed the issue.

### Improved Tests
The two relevant tests are for testing the single byte and buffered read methods in SpeedStream.java. The tests both work by starting with known data and a known checksum. It creates a `SpeedStream` object out of the data and then streams it, computing the checksum (in the SpeedStream::read method) as it streams. The resulting checksum is then checked against the known checksum.


### Addition of Apache Commons
The original issue that is attached to this PR was about the checksum being unreable (random unicode) in the manifest files. The reason for the output appearing how id did was that it wasn't hex encoded. There's a small change to encode the output, which produces a more valid-looking checksum. I think that this is the only library preventing this from being pure Java; I'm definitely open to non apache ways to get rid of the dependancy.

### To Test:
There are a couple of different ways to test the value of the checksums.

Method 1:
1. Checkout this branch
2. Make sure SpeedBagIt builds
3. Run the unit tests
4. Observe these unit tests failing

Method 2:
It's also possible to look in the manifest files for the checksum value. Currently, a hello-world.zip file is being created in the project root when the SpeedBagIt unit tests are run. PR #10 changes this so that unit tests use temporary directories that are destroyed after each test.


##### [START] Currently not valid, but will be when PR #10 is merged
This method is for observing the manifest file checksums (created by the SpeedStream). The bags are created in temporary directories that are destroyed after each test run. Either place a breakpoint at the end, or Thread.sleep(someAmountofTime).

1. Checkout this branch
2. Make sure SpeedBagIt builds
3. Place a breakpoint somewhere [after the bag streams](https://github.com/DataONEorg/speed-bagit/blob/main/src/test/java/org/dataone/SpeedBagItTest.java#L85)
3. Run the unit tests under the debugger
4. Observe the value of the bagPath
5. Open the path and see the bag zip file

##### [END] Currently not valid, but will be when PR #10 is merged

Method 3
1. Clone this [example](https://github.com/ThomasThelen/payload_bag)
2. Clone this repository
3. Checkout this branch
4. Build the Jar file
5. Drop it into the `resources/` folder in the example project
6. Link the Jar to the project (depends on IDE)
7. Execute the Main class
8. Observe the checksums in the manifest files
