### PR TITLE
Add 'Bagging-Date' to properties

### DIFF
--- a/src/main/java/org/dataone/speedbagit/SpeedBagIt.java
+++ b/src/main/java/org/dataone/speedbagit/SpeedBagIt.java
@@ -206,7 +206,7 @@ public class SpeedBagIt {
         String bagInfoDateKey = this.properties.getProperty("bag.info.date");
         String bagInfo = String.format("%s: %s\n", bagInfoDateKey, dateFormat.format(dateTime));
         String bagInfoPayloadOxum = this.properties.getProperty("bag.info.payloadOxum");
-        bagInfo = String.format("%s%sPayload-Oxum: %s\n", bagInfo, bagInfoPayloadOxum, payloadOxum);
+        bagInfo = String.format("%s%s: %s\n", bagInfo, bagInfoPayloadOxum, payloadOxum);
         String bagInfoBagSize = this.properties.getProperty("bag.info.bagSize");
         bagInfo = String.format("%s%s: %s\n", bagInfo, bagInfoBagSize, formatSize(bagSize));
         return bagInfo;

--- a/src/main/resources/speed-bagit.properties
+++ b/src/main/resources/speed-bagit.properties
@@ -7,3 +7,4 @@ bagit.file.name=bagit.txt
 bag.info.file.name=bag-info.txt
 bag.info.payloadOxum=Payload-Oxum
 bag.info.bagSize=Bag-Size
+bag.info.date=Bagging-Date


### PR DESCRIPTION
Small bug fix where `bag.info.date` wasn't found [here](https://github.com/DataONEorg/speed-bagit/blob/main/src/main/java/org/dataone/speedbagit/SpeedBagIt.java#L206)

Also fixes an issue of two "Payload-Oxum" strings in the bag-info