### PR TITLE
Check for name collisions between files as they're added to the bag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.dataone</groupId>
   <artifactId>speedbagit</artifactId>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
   <packaging>jar</packaging>
   <name>speedbagit</name>
   <url>http://maven.apache.org</url>

--- a/src/test/java/org/dataone/speedbagit/ProfilingTest.java
+++ b/src/test/java/org/dataone/speedbagit/ProfilingTest.java
@@ -54,7 +54,7 @@ public class ProfilingTest {
 	 */
 	@Test
 	@Disabled
-	public void testLargeFiles() throws IOException, NoSuchAlgorithmException {
+	public void testLargeFiles() throws IOException, NoSuchAlgorithmException, SpeedBagException {
 		// Create 100, 1GB files
 		GenerateFiles("largeFiles/", 100, 1000000000L);
 		CreateBag("largeFiles/", "./bagged_data.zip");
@@ -66,7 +66,7 @@ public class ProfilingTest {
 	 */
 	@Test
 	@Disabled
-	public void testSmallFiles() throws IOException, NoSuchAlgorithmException {
+	public void testSmallFiles() throws IOException, NoSuchAlgorithmException, SpeedBagException {
 		GenerateFiles("smallFiles/", 5000, 1000);
 		CreateBag("smallFiles/", "./bagged_data.zip");
 	}
@@ -118,7 +118,7 @@ public class ProfilingTest {
 	 * @param PayloadPath The path to the data directory that will be bagged
 	 * @param bagPath The path to the bagit archive that will be created
 	 */
-	public static void CreateBag(String PayloadPath, String bagPath) throws IOException, NoSuchAlgorithmException {
+	public static void CreateBag(String PayloadPath, String bagPath) throws IOException, NoSuchAlgorithmException, SpeedBagException {
 		SpeedBagIt bag = new SpeedBagIt(1.0, "MD5");
 		File dataDirectory = new File(PayloadPath);
 		File[] directoryListing = dataDirectory.listFiles();
@@ -140,3 +140,4 @@ public class ProfilingTest {
         IOUtils.copy(bagStream, fos);
 	}
 }
+

--- a/src/test/java/org/dataone/speedbagit/ProfilingTest.java
+++ b/src/test/java/org/dataone/speedbagit/ProfilingTest.java
@@ -43,8 +43,8 @@ import java.util.zip.ZipOutputStream;
 
 /**
  * A suite of tests that should be run under a profiler and ignored by CI systems and ordinary builds.
- * These should be run before each release to ensure that emory management is
- * sane (ie entire files aren't loaded into memory at once).
+ * These should be run before each release to ensure that memory management is
+ * working properly (ie entire files aren't loaded into memory at once).
  */
 
 public class ProfilingTest {

--- a/src/test/java/org/dataone/speedbagit/SpeedBagItTest.java
+++ b/src/test/java/org/dataone/speedbagit/SpeedBagItTest.java
@@ -49,10 +49,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-
+import static org.junit.jupiter.api.Assertions.*;
 
 
 /**
@@ -340,15 +337,15 @@ public class SpeedBagItTest {
 
 
         SpeedBagIt bag = getStockBag();
-        List<SpeedFile> dataFiles = bag.getDataFiles();
+        HashMap<String, SpeedFile> dataFiles = bag.getDataFiles();
         assert dataFiles.size() == 2;
-        for (SpeedFile dataFile: dataFiles) {
+        for (SpeedFile dataFile: dataFiles.values()) {
             assert expectedDataPaths.contains(dataFile.getPath());
         }
 
-        List<SpeedFile> metadataFiles = bag.getTagFiles();
+        HashMap<String, SpeedFile> metadataFiles = bag.getTagFiles();
         assert metadataFiles.size() == 2;
-        for (SpeedFile tagFile: metadataFiles) {
+        for (SpeedFile tagFile: metadataFiles.values()) {
             assert expecteMetadataPaths.contains(tagFile.getPath());
         }
     }
@@ -356,14 +353,14 @@ public class SpeedBagItTest {
     @Test
     public void testGetDataFiles() throws SpeedBagException, NoSuchAlgorithmException, IOException {
         SpeedBagIt bag = getStockBag();
-        List<SpeedFile> dataFiles = bag.getDataFiles();
+        HashMap<String, SpeedFile> dataFiles = bag.getDataFiles();
         assert dataFiles.size() == 2;
     }
 
     @Test
     public void testGetTagFiles() throws SpeedBagException, NoSuchAlgorithmException, IOException {
         SpeedBagIt bag = getStockBag();
-        List<SpeedFile> metadataFiles = bag.getTagFiles();
+        HashMap<String, SpeedFile> metadataFiles = bag.getTagFiles();
         assert metadataFiles.size() == 2;
     }
 


### PR DESCRIPTION
Fixes #27 

Nothing too wild here. I condensed one of the `addFile` methods down, added a private method for checking two paths, and added a unit test to make sure we're throwing when this happens 