### PR TITLE
Merge develop to main for 1.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.dataone</groupId>
   <artifactId>speedbagit</artifactId>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
   <packaging>jar</packaging>
   <name>speedbagit</name>
   <url>https://github.com/DataONEorg/speed-bagit</url>
@@ -143,7 +143,7 @@
             </goals>
             <phase>deploy</phase>
             <configuration>
-              <url>${project.url}</url>
+              <url>${url}</url>
               <groupId>${project.groupId}</groupId>
               <artifactId>${project.artifactId}</artifactId>
               <file>${project.build.directory}/${project.build.finalName}.jar</file>
@@ -222,7 +222,7 @@
       <uniqueVersion>false</uniqueVersion>
       <id>jenkins.dataone.org</id>
       <name>DataONE</name>
-      <url>${project.url}</url>
+      <url>${url}</url>
       <layout>default</layout>
     </repository>
   </distributionManagement>


### PR DESCRIPTION
I searched the code base and compared the commit history, and found the only place to hold the version number is pom.xml. So I think the change of pom.xml  is good enough for this release, which just fixed the issue on the deploy process. 