### PR TITLE
Propagate errors to the consumer

### DIFF
--- a/src/main/java/org/dataone/speedbagit/SpeedBagIt.java
+++ b/src/main/java/org/dataone/speedbagit/SpeedBagIt.java
@@ -23,6 +23,7 @@
 package org.dataone.speedbagit;
 
 import java.io.ByteArrayInputStream;
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PipedInputStream;
@@ -41,6 +42,7 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -288,6 +290,7 @@ public class SpeedBagIt {
         PipedOutputStream ps = new PipedOutputStream();
         PipedInputStream is = new PipedInputStream(ps);
         ZipOutputStream zos = new ZipOutputStream(ps);
+        AtomicReference<Exception> failure = new AtomicReference<>();
 
         executor.execute(
             new Runnable() {
@@ -355,13 +358,39 @@ public class SpeedBagIt {
                         zos.close();
                         timeStamp = new SimpleDateFormat("yyyy.MM.dd.HH.mm.ss").format(new Date());
                         logger.info(String.format("Finished streaming bag at %s", timeStamp));
-                        
+
                     } catch (Exception e) {
-                        e.printStackTrace();
+                        logger.error("Error streaming bag", e);
+                        failure.set(e);
+                    } finally {
+                        try { zos.close(); } catch (IOException ignored) {}
+                        try { ps.close(); } catch (IOException ignored) {}
                     }
                 }
             });
-        return is;
+
+        return new FilterInputStream(is) {
+            @Override
+            public int read() throws IOException {
+                int b = super.read();
+                if (b == -1) checkFailure();
+                return b;
+            }
+
+            @Override
+            public int read(byte[] buf, int off, int len) throws IOException {
+                int n = super.read(buf, off, len);
+                if (n == -1) checkFailure();
+                return n;
+            }
+
+            private void checkFailure() throws IOException {
+                Exception ex = failure.get();
+                if (ex != null) {
+                    throw new IOException("Bag streaming failed", ex);
+                }
+            }
+        };
     }
 
     /**

--- a/src/test/java/org/dataone/speedbagit/SpeedBagItTest.java
+++ b/src/test/java/org/dataone/speedbagit/SpeedBagItTest.java
@@ -470,5 +470,31 @@ public class SpeedBagItTest {
             bag.addFile(dataFile2Stream, "tag/data_file1.csv", true);
         });
     }
+
+    /**
+     * Tests that when streaming fails in the background thread, the caller
+     * receives an IOException rather than silently getting a truncated stream.
+     */
+    @Test
+    public void testStreamPropagatesError() throws IOException, NoSuchAlgorithmException, SpeedBagException {
+        SpeedBagIt bag = new SpeedBagIt(1.0, "MD5");
+
+        // Add a stream that throws on read, which will cause the background thread to fail
+        InputStream failingStream = new InputStream() {
+            @Override
+            public int read() throws IOException {
+                throw new IOException("simulated read failure");
+            }
+        };
+        bag.addFile(failingStream, "data/bad_file.csv", false);
+
+        InputStream bagStream = bag.stream();
+        assertThrows(IOException.class, () -> {
+            byte[] buf = new byte[1024];
+            while (bagStream.read(buf) != -1) {
+                // drain until error
+            }
+        });
+    }
 }
 

--- a/src/test/java/org/dataone/speedbagit/SpeedBagItTest.java
+++ b/src/test/java/org/dataone/speedbagit/SpeedBagItTest.java
@@ -24,6 +24,7 @@ package org.dataone.speedbagit;
 
 import java.io.ByteArrayInputStream;
 import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.StringReader;
@@ -494,6 +495,32 @@ public class SpeedBagItTest {
             while (bagStream.read(buf) != -1) {
                 // drain until error
             }
+        });
+    }
+
+    /**
+     * Tests that when streaming fails in the background thread, the caller
+     * receives an IOException rather than silently getting a truncated stream. It uses copyLarge
+     * to test the method
+     */
+    @Test
+    public void testStreamPropagatesError2() throws IOException, NoSuchAlgorithmException,
+        SpeedBagException {
+        SpeedBagIt bag = new SpeedBagIt(1.0, "MD5");
+
+        // Add a stream that throws on read, which will cause the background thread to fail
+        InputStream failingStream = new InputStream() {
+            @Override
+            public int read() throws IOException {
+                throw new IOException("simulated read failure");
+            }
+        };
+        bag.addFile(failingStream, "data/bad_file.csv", false);
+
+        InputStream bagStream = bag.stream();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream(100000000);
+        assertThrows(IOException.class, () -> {
+            IOUtils.copyLarge(bagStream, outputStream);
         });
     }
 }


### PR DESCRIPTION
Speedbagit has this unfortunate feature where, if something goes wrong while the bag is being created/streamed, an corrupt zip file will be the output. This change propagates the error back to the consumer (let's say metacat) so that it can be handled, and includes the error reason.

In MNResourceHandler.java:1539, IOUtils.copyLarge(is, out) reads from the InputStream returned by speedBag.stream(). If the background thread in SpeedBagIt fails, the old code just calls e.printStackTrace() and the pipe closes silently. Metacat already handles the io exception, so no code changes are needed on that side.